### PR TITLE
fix README typo error on line 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 ## ⚡️About
 
-[Piggment](https://piggment.co) A curated collection of amazingly colored gradients for designers, developers and art makers over the world. **Gets gradeints and pallets on the fly**.
+[Piggment](https://piggment.co): A curated collection of amazingly colored gradients for designers, developers and art makers over the world. **Gets gradeints and pallets on the fly**.
 
-**Using piggment** in **project** provides an **easy way** of **getting inspiring gradients and palettes** goto to [Piggment.co](https://piggment.co) to start using now.
+**Using piggment** in **project** provides an **easy way** of **getting inspiring gradients and palettes** go to [Piggment.co](https://piggment.co) to start using now.
 
 ### Generate Palette
 


### PR DESCRIPTION
**Description**

This is a pull request for fixing the typo error on the README.md file which uses "goto to" instead of "go to" and also made few changes to the README files for a much better and proper description of Piggment.

**Fixes** 
Just few changes to the README for a proper documentation




